### PR TITLE
[Xerath] UT 진행 후 기능적 피드백 반영

### DIFF
--- a/Alright/Alright.xcodeproj/project.pbxproj
+++ b/Alright/Alright.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -559,6 +560,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Alright/Alright/Source/Helper/VoicePitchButton.swift
+++ b/Alright/Alright/Source/Helper/VoicePitchButton.swift
@@ -84,6 +84,7 @@ struct VoicePitchButton: View {
             print("Ending the Live Activity: \(currentActivity.id)")
             // Activity 객체를 nil로 설정
             self.activity = nil
+            self.noiseMeter.timer = nil
         }
     }
 }

--- a/Alright/Alright/Source/Helper/VoicePitchButton.swift
+++ b/Alright/Alright/Source/Helper/VoicePitchButton.swift
@@ -4,13 +4,12 @@ import ActivityKit
 struct VoicePitchButton: View {
     
     let action: () -> Void
-    
-    @Binding var height: CGFloat
+
     @Binding var noiseMeter: NoiseMeter
     
     // 상태 변화를 감지하기 위한 변수를 추가합니다.
     @State private var currentNoiseLevel: NoiseLevel = .notMeasuring
-    @State private var activity: Activity<DynamicIslandWidgetAttributes>? // Activity 객체를 관리하는 상태 변수 추가
+    @Binding var activity: Activity<DynamicIslandWidgetAttributes>? // Activity 객체를 관리하는 상태 변수 추가
     
     var body: some View {
         Button {
@@ -90,7 +89,10 @@ struct VoicePitchButton: View {
 }
 
 #Preview {
-    VoicePitchButton(action: { print("측정버튼을 클릭했습니다.")},
-                     height: .constant(200),
-                     noiseMeter: .constant(NoiseMeter()))
+    Group {
+        VoicePitchButton(action: { print("측정버튼을 클릭했습니다.")},
+                         noiseMeter: .constant(NoiseMeter()),
+                         activity: .constant(nil))
+        
+    }
 }

--- a/Alright/Alright/Source/View/FeedbackView.swift
+++ b/Alright/Alright/Source/View/FeedbackView.swift
@@ -68,6 +68,7 @@ struct FeedbackView: View {
             print("Ending the Live Activity: \(currentActivity.id)")
             // Activity 객체를 nil로 설정
             self.activity = nil
+            self.noiseMeter.timer = nil
         }
     }
     

--- a/Alright/Alright/Source/View/FeedbackView.swift
+++ b/Alright/Alright/Source/View/FeedbackView.swift
@@ -1,9 +1,13 @@
 
 import SwiftUI
+import ActivityKit
 
 struct FeedbackView: View {
     
     @Environment(\.dismiss) private var dismiss
+    
+    @State private var noiseMeter = NoiseMeter()
+    @State private var activity: Activity<DynamicIslandWidgetAttributes>?
     
     // 선택한 상황에 따라서 currentIndex(0~3)에 맞춰서 데시벨 다르게
     @Binding var currentIndex: Int? // 현재 선택한 상황 index
@@ -15,7 +19,9 @@ struct FeedbackView: View {
                 Color.sgmGray2
                     .ignoresSafeArea()
                 
-                VoicePitchView()
+                VoicePitchView(measure: measure, 
+                               activity: $activity,
+                               noiseMeter: $noiseMeter)
                 .navigationBarBackButtonHidden()
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
@@ -26,6 +32,12 @@ struct FeedbackView: View {
                     }
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button {
+                            // 측정을 멈추고 라이브 액티비티 종료
+                            if noiseMeter.isMeasuring {
+                                Task {
+                                    await endLiveActivity()
+                                }
+                            }
                             dismiss()
                         } label: {
                             Text("종료")
@@ -34,9 +46,33 @@ struct FeedbackView: View {
                     }
                 }
             }
+            .onAppear{
+                Task {
+                    await measure()
+                }
+            }
         }
     }
+    
+    private func measure() async {
+        if noiseMeter.timer == nil {
+            await noiseMeter.startMetering()
+        } else {
+            await noiseMeter.stopMetering()
+        }
+    }
+    
+    private func endLiveActivity() async {
+        if let currentActivity = activity {
+            await currentActivity.end(nil,dismissalPolicy: .immediate)
+            print("Ending the Live Activity: \(currentActivity.id)")
+            // Activity 객체를 nil로 설정
+            self.activity = nil
+        }
+    }
+    
 }
+
 
 #Preview {
     FeedbackView(

--- a/Alright/Alright/Source/View/VoicePitchView.swift
+++ b/Alright/Alright/Source/View/VoicePitchView.swift
@@ -7,11 +7,13 @@
 
 import SwiftUI
 import AVFoundation
+import ActivityKit
 
 struct VoicePitchView: View {
     
-    @State private var noiseMeter = NoiseMeter()
-    @State private var circleHeight: CGFloat = 0
+    let measure: (() async -> ())
+    @Binding var activity: Activity<DynamicIslandWidgetAttributes>?
+    @Binding var noiseMeter: NoiseMeter
     
     var isMeasuring: Bool {
         self.noiseMeter.timer != nil
@@ -19,7 +21,7 @@ struct VoicePitchView: View {
     
     var noiseLevel: NoiseLevel {
         NoiseLevel.level(for: noiseMeter.decibels,
-                              isMeasuring: isMeasuring)
+                         isMeasuring: isMeasuring)
     }
     
     var body: some View {
@@ -47,24 +49,11 @@ struct VoicePitchView: View {
                 
                 Text("\(String(format: "%.2f", noiseMeter.decibels))dB")
                     .foregroundStyle(.white)
-                VoicePitchButton(action: { Task { await measure(height: circleHeight) } },
-                                 height: $circleHeight,
-                                 noiseMeter: $noiseMeter)
+                VoicePitchButton(action: { Task { await measure() } },
+                                 noiseMeter: $noiseMeter,
+                                 activity: $activity)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-        .onAppear{
-            Task {
-                await measure(height: circleHeight)
-            }
-        }
-    }
-    
-    private func measure(height: CGFloat) async {
-        if noiseMeter.timer == nil {
-            await noiseMeter.startMetering()
-        } else {
-            await noiseMeter.stopMetering()
         }
     }
 }
@@ -156,6 +145,10 @@ enum NoiseLevel: String, Codable {
 }
 
 
-#Preview {
-    VoicePitchView()
-}
+//#Preview {
+//    VoicePitchView(measure: {
+//        
+//    },
+//                   activity: .constant(nil),
+//                   noiseMeter: .constant(NoiseMeter()))
+//}

--- a/Alright/DyanmicIsland/DyanmicIslandLiveActivity.swift
+++ b/Alright/DyanmicIsland/DyanmicIslandLiveActivity.swift
@@ -22,6 +22,7 @@ struct DynamicIslandWidgetLiveActivity: Widget {
                 Text(context.state.message)
                 ProgressView(value: context.state.progress, total: 1.0)
                     .progressViewStyle(LinearProgressViewStyle())
+                    .tint(context.state.noiseLevel.noiseColor)
                     .frame(height: 10)
                     .padding(.horizontal)
             }


### PR DESCRIPTION
## 📓 Overview

- 유저가 가장 반영할 수 있는 다크 모드와 라이트 모드 동일하게 반영하여 구현했습니다.
- Live Activity - Lock Screen 모드의 Progress View의 색상이 목소리 크기에 따라 변경되도록 반영했습니다.
- 목소리 측정 중 종료 버튼 클릭 시 Live Activity가 종료되지 않는 이슈를 해결했습니다.
- Live Activity 해제 시 녹음 Timer가 해제되지 않는 이슈를 해결했습니다.

## 🤔 고민 내용
### Live Activity Service의 객체화 
> 현재 Live Activity와 음성 녹음 기능(NoiseMeter)을 각각 따로 Service를 가지고 있습니다.(정확히는 음성 녹음 기능만을 Service로 들고 있고, Live Activity는 View에서 직접 들고서 function과 함께 들고 있는 형태입니다.)
현재는 문제가 없으나 추후 Live Activity를 다루는 기능 규모가 커질 시 따로 Service 객체로 빼주는게 나을 것 같다는 생각이 듭니다.
다만, Live Activity와 NoiseMeter를 하나의 ViewModel에서 들고 있는게 맞을지 의문입니다.
함께 엮이는 기능이지만, 분명 서로 다른 것을 타겟팅하기 때문에 ViewModel 구성이 고민입니다.

## 📸 Screenshot

<img width="300" alt="[Xerath] UT 진행 후 기능적 피드백 반영 시뮬레이션" src="https://github.com/user-attachments/assets/2dd2d030-ad1d-4afe-ab35-f0181ec47732" />
