### PR TITLE
[Mars] 도움말 기능인 CustomBottomSheet 추가

### DIFF
--- a/Alright/Alright.xcodeproj/project.pbxproj
+++ b/Alright/Alright.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		08FE6DE62C5D1AB400A2E52B /* NoiseLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F4F1D72C5D1A2100F89B2C /* NoiseLevel.swift */; };
 		08FE6DE82C5D1C2E00A2E52B /* SelectionRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FE6DE72C5D1C2E00A2E52B /* SelectionRectangle.swift */; };
 		08FE6DE92C5D1D1E00A2E52B /* SelectionRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FE6DE72C5D1C2E00A2E52B /* SelectionRectangle.swift */; };
+		1F44B1252C63D394006B06BC /* InfoSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F44B1242C63D394006B06BC /* InfoSheetView.swift */; };
+		1F44B1262C63D3C7006B06BC /* InfoSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F44B1242C63D394006B06BC /* InfoSheetView.swift */; };
 		1F77AA0C2C52241300402A2E /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F77AA0B2C52241300402A2E /* FeedbackView.swift */; };
 		1F857FBC2C59E4810043F012 /* NoiseMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088DFC6C2C53346C00469FD1 /* NoiseMeter.swift */; };
 		1FB5A4C02C59E1370029B181 /* SelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08621D212C5763BA00E26998 /* SelectionView.swift */; };
@@ -119,6 +121,7 @@
 		08F4F1D72C5D1A2100F89B2C /* NoiseLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoiseLevel.swift; sourceTree = "<group>"; };
 		08FE6DE72C5D1C2E00A2E52B /* SelectionRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionRectangle.swift; sourceTree = "<group>"; };
 		1D9231C22C57ED0C00819BC7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		1F44B1242C63D394006B06BC /* InfoSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoSheetView.swift; sourceTree = "<group>"; };
 		1F77AA0B2C52241300402A2E /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
 		1FF46DE12C59DDE700FE3D90 /* DyanmicIslandExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DyanmicIslandExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FF46DE32C59DDE700FE3D90 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
@@ -163,6 +166,7 @@
 			isa = PBXGroup;
 			children = (
 				1F77AA0B2C52241300402A2E /* FeedbackView.swift */,
+				1F44B1242C63D394006B06BC /* InfoSheetView.swift */,
 				08C737EE2C51F5D100FA93A4 /* VoicePitchView.swift */,
 				088DFC6E2C534AA800469FD1 /* GaugeView.swift */,
 				08FE6DE72C5D1C2E00A2E52B /* SelectionRectangle.swift */,
@@ -468,6 +472,7 @@
 				1FB5A4C22C59E1580029B181 /* AppIntent.swift in Sources */,
 				08F4F1D82C5D1A2100F89B2C /* NoiseLevel.swift in Sources */,
 				08621D222C5763BA00E26998 /* SelectionView.swift in Sources */,
+				1F44B1252C63D394006B06BC /* InfoSheetView.swift in Sources */,
 				08332F6F2C62A1EF00F3D57A /* Situation.swift in Sources */,
 				088DFC6D2C53346C00469FD1 /* NoiseMeter.swift in Sources */,
 				088DFC6F2C534AA800469FD1 /* GaugeView.swift in Sources */,
@@ -493,6 +498,7 @@
 				1FF46DE92C59DDE700FE3D90 /* DyanmicIslandBundle.swift in Sources */,
 				1FD39F382C59E53D005067DF /* GaugeView.swift in Sources */,
 				1F857FBC2C59E4810043F012 /* NoiseMeter.swift in Sources */,
+				1F44B1262C63D3C7006B06BC /* InfoSheetView.swift in Sources */,
 				1FF46DEB2C59DDE700FE3D90 /* DyanmicIslandLiveActivity.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Alright/Alright/Resource/Assets.xcassets/sgmGray3.colorset/Contents.json
+++ b/Alright/Alright/Resource/Assets.xcassets/sgmGray3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Alright/Alright/Source/Helper/RoundedCorner.swift
+++ b/Alright/Alright/Source/Helper/RoundedCorner.swift
@@ -19,3 +19,9 @@ struct RoundedCorner: Shape {
         return Path(path.cgPath)
     }
 }
+
+//extension View {
+//    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+//        clipShape(RoundedCorner(radius: radius, corners: corners))
+//    }
+//}

--- a/Alright/Alright/Source/Helper/RoundedCorner.swift
+++ b/Alright/Alright/Source/Helper/RoundedCorner.swift
@@ -19,9 +19,3 @@ struct RoundedCorner: Shape {
         return Path(path.cgPath)
     }
 }
-
-//extension View {
-//    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
-//        clipShape(RoundedCorner(radius: radius, corners: corners))
-//    }
-//}

--- a/Alright/Alright/Source/Model/Situation.swift
+++ b/Alright/Alright/Source/Model/Situation.swift
@@ -61,4 +61,13 @@ enum Situation {
             (65, 75)
         }
     }
+    
+    var infoMessage: String {
+        switch self {
+        case .quietTalking, .loudTalking:
+            "팔을 앞으로 쭉 편 후\n손이 위치하는 거리에 스마트폰을 놓아주세요."
+        case .meetingRoom, .auditorium:
+            "스크립트를 볼 수 있는 정도로\n자연스럽게 스마트폰을 들어주세요."
+        }
+    }
 }

--- a/Alright/Alright/Source/View/Feedback/FeedbackView.swift
+++ b/Alright/Alright/Source/View/Feedback/FeedbackView.swift
@@ -5,6 +5,7 @@ import ActivityKit
 struct FeedbackView: View {
     
     @Environment(\.dismiss) private var dismiss
+    @State private var isInfoSheetPresented = false
     
     @State private var noiseMeter = NoiseMeter.shared
     @State private var activity: Activity<DynamicIslandWidgetAttributes>?
@@ -23,12 +24,22 @@ struct FeedbackView: View {
                 .navigationBarBackButtonHidden()
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button {
+                            isInfoSheetPresented = true
+                        } label: {
+                            Image(systemName: "questionmark.circle")
+                                .foregroundColor(.sgmBlue1)
+                        }
+                    }
+                    
                     ToolbarItem(placement: .principal) {
                         Text(currentSituation?.title ?? "")
                             .font(.Pretendard.SemiBold.size17)
                             .kerning(-0.43)
                             .foregroundColor(.white)
                     }
+                    
                     ToolbarItem(placement: .navigationBarTrailing) {
                         // 종료 버튼
                         Button {
@@ -45,6 +56,7 @@ struct FeedbackView: View {
                         }
                     }
                 }
+                InfoSheetView(isShowing: $isInfoSheetPresented, nowSituation: $currentSituation)
             }
             .onAppear { // FeedBackView 시작 시 소리 측정 시작
                 Task {
@@ -56,13 +68,13 @@ struct FeedbackView: View {
             .onDisappear {
                 currentSituation = nil
             }
+            
         }
     }
 }
 
-
-//#Preview {
-//    FeedbackView(
-//        currentSituation: .constant(Situation.auditorium)
-//    )
-//}
+#Preview {
+    FeedbackView(
+        currentSituation: .constant(Situation.auditorium)
+    )
+}

--- a/Alright/Alright/Source/View/Feedback/InfoSheetView.swift
+++ b/Alright/Alright/Source/View/Feedback/InfoSheetView.swift
@@ -1,0 +1,86 @@
+//
+//  TipSheetView.swift
+//  Alright
+//
+//  Created by 이상도 on 8/8/24.
+//
+
+import SwiftUI
+
+struct InfoSheetView: View {
+    
+    @Binding var isShowing: Bool
+    @Binding var nowSituation: Situation?
+    
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            if isShowing {
+                Color.black
+                    .opacity(0.6)
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        withAnimation {
+                            isShowing = false
+                        }
+                    }
+                
+                VStack(spacing: 0) {
+                    Divider()
+                        .frame(width:64, height: 4)
+                        .background(.sgmBlue3)
+                        .cornerRadius(4)
+                        .padding(.top)
+                    Spacer()
+                    
+                    HStack {
+                        Text("스마트폰의 위치를 설정해주세요!")
+                            .font(.Pretendard.SemiBold.size22)
+                            .foregroundColor(.white)
+                            .padding(.leading)
+                        Spacer()
+                    }
+                    .padding(.top, 5)
+                    .padding(.bottom)
+                    
+                    HStack {
+                        Text("\(nowSituation?.infoMessage ?? "")")
+                            .font(.Pretendard.Medium.size18)
+                            .foregroundColor(.white)
+                            .lineSpacing(4)
+                            .padding(.leading)
+                        Spacer()
+                    }
+                    Spacer()
+                    
+                    Button {
+                        isShowing = false
+                    } label: {
+                        Text("확인")
+                            .font(.Pretendard.SemiBold.size17)
+                            .frame(maxWidth: .infinity, maxHeight: 50)
+                            .background(
+                                LinearGradient(
+                                    gradient: .init(colors: [Color(hex: "#394999"),
+                                                             Color(hex: "#4C61CC"),
+                                                             Color(hex: "#6079FF")]),
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                ))
+                            .foregroundColor(.white)
+                            .cornerRadius(12)
+                    }
+                    .padding()
+                }
+                .frame(maxWidth: .infinity, maxHeight: 222)
+                .background(.sgmGray3)
+                .cornerRadius(16)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                .padding(.horizontal)
+                .padding(.bottom, 20)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .ignoresSafeArea()
+        .animation(.easeInOut, value: isShowing)
+    }
+}

--- a/Alright/Alright/Source/View/Feedback/InfoSheetView.swift
+++ b/Alright/Alright/Source/View/Feedback/InfoSheetView.swift
@@ -17,7 +17,6 @@ struct InfoSheetView: View {
             if isShowing {
                 Color.black
                     .opacity(0.6)
-                    .ignoresSafeArea()
                     .onTapGesture {
                         withAnimation {
                             isShowing = false


### PR DESCRIPTION
## 📓 Overview
-  도움말 버튼을 눌렀을때 하단에 등장하는 SheetView를 커스텀하여 추가하였습니다.

## 🤔 고민 내용
- 도움말 SheetView가 현재 InfoSheetView이름으로 생성하였는데, Feedback 그룹에 있는게 맞겠죠 ?
- 안내 메세지가 상황별로 2가지로 나뉘는데, 2가지밖에 안돼서 그냥 InfoSheetView내에서 삼항연산자로 적용을 할까 하다가, Situation 모델에 추가를 해서 적용을 했는데 이게 더 깔끔한게 맞을까요 ? 

### 디자인
도움말SheetView내에 Text도 생각보다 프레임에 꽉차서 혹시하고 12mini로도 돌려보았는데요. 
SheetView는 괜찮았는데, SelectionView 텍스트들이 짤리더라구요 ! 
아마 기존에 제가 뷰를 짯을 땐 width는 동적으로 계속 꽉차게하고 height만 고정했었는데, 디자인 피드백 코멘트를 안나가 남길때
오토레이아웃은 조금은 고려안하고 코멘트를 남겼던걸로 알아요. 
내일 이것부터 안나랑 다시 얘기하고 슥 고치고나서 나머지 할 일 진행해도 괜찮을 것 같네요 ! ㅎㅎ 
<img src="https://github.com/user-attachments/assets/e02630b2-aefb-4ae7-bc31-f4f46d2c3f47" width="200px;">

## 📸 Screenshot
<img src="https://github.com/user-attachments/assets/7e86b96e-238b-4591-9cfa-8fe4ba900b5e" width="200px;">


