### PR TITLE
[Xerath] Launch Screen, Onboarding 페이지 내 Animation 추가 설정

### DIFF
--- a/Alright/Alright.xcodeproj/project.pbxproj
+++ b/Alright/Alright.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		08328DE32C68A1DC007D32A3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08328DE22C68A1DC007D32A3 /* ContentView.swift */; };
 		08332F6F2C62A1EF00F3D57A /* Situation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08332F6E2C62A1EF00F3D57A /* Situation.swift */; };
 		08332F702C62AA4800F3D57A /* Situation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08332F6E2C62A1EF00F3D57A /* Situation.swift */; };
 		08332F732C62B2D100F3D57A /* DotLottie in Frameworks */ = {isa = PBXBuildFile; productRef = 08332F722C62B2D100F3D57A /* DotLottie */; };
@@ -100,6 +101,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		08328DE22C68A1DC007D32A3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		08332F6E2C62A1EF00F3D57A /* Situation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Situation.swift; sourceTree = "<group>"; };
 		08332F742C62B32600F3D57A /* splashScreen.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = splashScreen.lottie; sourceTree = "<group>"; };
 		08332F7B2C62B5A700F3D57A /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 			isa = PBXGroup;
 			children = (
 				08808F5E2C57629300A6A8FA /* SipGuManApp.swift */,
+				08328DE22C68A1DC007D32A3 /* ContentView.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -482,6 +485,7 @@
 			files = (
 				08808F5F2C57629300A6A8FA /* SipGuManApp.swift in Sources */,
 				1F0B71C02C65BC09006DEECD /* AppOnboardingView.swift in Sources */,
+				08328DE32C68A1DC007D32A3 /* ContentView.swift in Sources */,
 				1FF46DFA2C59DE1300FE3D90 /* DyanmicIslandLiveActivity.swift in Sources */,
 				08332F7C2C62B5A700F3D57A /* LottieView.swift in Sources */,
 				088DFC752C5394BC00469FD1 /* RoundedCorner.swift in Sources */,

--- a/Alright/Alright/Source/Application/ContentView.swift
+++ b/Alright/Alright/Source/Application/ContentView.swift
@@ -1,0 +1,37 @@
+//
+//  ContentView.swift
+//  Alright
+//
+//  Created by 윤동주 on 8/11/24.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    
+    @State private var isLottieViewShown = true
+    
+    var body: some View {
+        VStack {
+            if isLottieViewShown {
+                LottieView()
+                    .opacity(isLottieViewShown ? 1 : 0)
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                            withAnimation(.linear(duration: 1.0)) {
+                                isLottieViewShown = false
+                            }
+                        }
+                    }
+            } else {
+                SelectionView()
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .edgesIgnoringSafeArea(.all)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Alright/Alright/Source/Application/ContentView.swift
+++ b/Alright/Alright/Source/Application/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
                 SelectionView()
             }
         }
+        .background(.sgmGray2)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .edgesIgnoringSafeArea(.all)
     }

--- a/Alright/Alright/Source/Application/SipGuManApp.swift
+++ b/Alright/Alright/Source/Application/SipGuManApp.swift
@@ -11,27 +11,9 @@ import DotLottie
 @main
 struct SipGuManApp: App {
     
-    @State private var isLottieViewShown = true
-    
     var body: some Scene {
         WindowGroup {
-            ZStack {
-                SelectionView()
-                
-                if isLottieViewShown {
-                    LottieView()
-                        .transition(.opacity)
-                        .onAppear {
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
-                                withAnimation(.easeOut(duration: 1.0)) {
-                                    isLottieViewShown = false
-                                }
-                            }
-                        }
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .edgesIgnoringSafeArea(.all)
+            ContentView()
         }
     }
 }

--- a/Alright/Alright/Source/View/Onboarding/AppOnboardingView.swift
+++ b/Alright/Alright/Source/View/Onboarding/AppOnboardingView.swift
@@ -12,9 +12,7 @@ struct AppOnboardingView: View {
     @Environment(\.dismiss) private var dismiss // Onboarding dismiss
     @AppStorage("isFirstOnboarding") private var isFirstOnboarding: Bool?
     
-    @State private var selectedPage = 0
-    
-    private let onboardingPages: [Onboarding] = [.first, .second, .third, .fourth]
+    @State private var selectedOnboarding: Onboarding = .first
     
     var body: some View {
         ZStack {
@@ -34,20 +32,21 @@ struct AppOnboardingView: View {
                             .foregroundColor(.sgmGrayA)
                     }
                     .padding(.trailing)
-                    .opacity(selectedPage == onboardingPages.count - 1 ? 0 : 1)
+                    .opacity(selectedOnboarding == .fourth ? 0 : 1)
                 }
                 
-                TabView(selection: $selectedPage) {
-                    ForEach(Array(Onboarding.allCases.enumerated()), id: \.element) { index, onboarding in
+                TabView(selection: $selectedOnboarding) {
+                    ForEach(Onboarding.allCases, id: \.self) { onboarding in
                         OnboardingPageView(
-                            nowOnboard: onboardingPages[index]
+                            nowOnboard: onboarding,
+                            selectedOnboarding: selectedOnboarding
                         )
-                        .id(index)
-                        .tag(index)
+                        .tag(onboarding)
                     }
                 }
                 .ignoresSafeArea()
                 .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+
             }
             
             // Indicator
@@ -55,11 +54,11 @@ struct AppOnboardingView: View {
                 Spacer()
                 
                 HStack(spacing: 8) {
-                    ForEach(onboardingPages.indices, id: \.self) { index in
+                    ForEach(Onboarding.allCases, id: \.self) { onboarding in
                         Circle()
                             .frame(width: 8, height: 8)
-                            .foregroundColor(index == selectedPage ? .sgmBlue1 : .sgmBlue1.opacity(0.3))
-                            .opacity(selectedPage == onboardingPages.count - 1 ? 0 : 1)
+                            .foregroundColor(selectedOnboarding == onboarding ? .sgmBlue1 : .sgmBlue1.opacity(0.3))
+                            .opacity(selectedOnboarding == .fourth ? 0 : 1)
                     }
                 }
                 .padding(.bottom, 40)

--- a/Alright/Alright/Source/View/Onboarding/AppOnboardingView.swift
+++ b/Alright/Alright/Source/View/Onboarding/AppOnboardingView.swift
@@ -46,7 +46,6 @@ struct AppOnboardingView: View {
                 }
                 .ignoresSafeArea()
                 .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-
             }
             
             // Indicator

--- a/Alright/Alright/Source/View/Onboarding/OnboardingPageView.swift
+++ b/Alright/Alright/Source/View/Onboarding/OnboardingPageView.swift
@@ -12,7 +12,10 @@ struct OnboardingPageView: View {
     @Environment(\.dismiss) private var dismiss
     @AppStorage("isFirstOnboarding") var isFirstOnboarding: Bool?
     
+    @State private var opacity = 0.0
+    
     var nowOnboard: Onboarding
+    var selectedOnboarding: Onboarding
     
     var body: some View {
         ZStack {
@@ -23,8 +26,18 @@ struct OnboardingPageView: View {
                             .resizable()
                     }
                     .frame(maxWidth: .infinity)
+                    .opacity(opacity)
+                    .onChange(of: selectedOnboarding) { _, newValue in
+                        if newValue == nowOnboard {
+                            withAnimation(.easeInOut(duration: 0.5)) {
+                                opacity = 1.0
+                            }
+                        } else {
+                            opacity = 0.0
+                        }
+                    }
                 }
-            
+                
                 VStack(spacing: 30) {
                     HStack {
                         Text("\(nowOnboard.onboardingTitle)")
@@ -71,6 +84,13 @@ struct OnboardingPageView: View {
                 .background(.sgmBlack)
             }
             .ignoresSafeArea(edges: .bottom)
+        }
+        .onAppear {
+            if selectedOnboarding == nowOnboard {
+                withAnimation(.easeInOut(duration: 0.5)) {
+                    opacity = 1.0
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## 📓 Overview

- Launch Screen에 올라가는 Lottie View에 fade out Animation을 적용했습니다.
- 도움말(Onboarding) Page에서 사용하는 이미지에 대한 Animation을 적용했습니다.

## 🤔 고민 내용

### Warning 해결
- 현재 생각보다 Warning이 자주 뜨는데 Critical한 문제는 아니긴 합니다. 
- 일단 Delight-Con 발표 이후 천천히 잡아보면 좋을 듯 합니다.

### Instrument 적용한 최적화
- 맥북으로 녹음을 실행 시 많이 뜨뜻해지는 현상이 있는데 뭔가 더 최적화해본다면 좋을 듯 합니다.
- 이 부분을 발견하기 위해 Instrument 학습 후 최적화 부분을 찾아보겠습니다.

## 📸 Screenshot
<img width="300" src="https://github.com/user-attachments/assets/caf19129-4f66-49b5-9cfb-d0865532f6df" />
